### PR TITLE
CI/CD: add travis config file and update tests to use fake client instead of controlpane.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - "1.13"
+
+go_import_path: github.com/alibaba/kubedl
+
+before_script:
+  - go mod download
+
+script:
+  - make test
+
+after_script:
+  - rm -f ./cover.out

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= alibaba/kube-dl:v1alpha1
+IMG ?= alibaba/kubedl:v1alpha1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 

--- a/api/pytorch/v1/v1_suite_test.go
+++ b/api/pytorch/v1/v1_suite_test.go
@@ -19,37 +19,23 @@ package v1
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var c client.Client
 
 func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
-	}
-
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	if _, err = t.Start(); err != nil {
 		log.Fatal(err)
 	}
 
 	c = fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	code := m.Run()
-	err = t.Stop()
-	if err != nil {
-		log.Fatal(err)
-	}
 	os.Exit(code)
 }

--- a/api/tensorflow/v1/v1_suite_test.go
+++ b/api/tensorflow/v1/v1_suite_test.go
@@ -19,37 +19,22 @@ package v1
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var c client.Client
 
 func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
-	}
-
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	if _, err = t.Start(); err != nil {
-		log.Fatal(err)
-	}
-
 	c = fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	code := m.Run()
-	err = t.Stop()
-	if err != nil {
-		log.Fatal(err)
-	}
 	os.Exit(code)
 }

--- a/api/xdl/v1alpha1/v1alpha1_suite_test.go
+++ b/api/xdl/v1alpha1/v1alpha1_suite_test.go
@@ -19,37 +19,24 @@ package v1alpha1
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var c client.Client
 
 func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
-	}
 
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if _, err = t.Start(); err != nil {
-		log.Fatal(err)
-	}
-
 	c = fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	code := m.Run()
-	err = t.Stop()
-	if err != nil {
-		log.Fatal(err)
-	}
 	os.Exit(code)
 }

--- a/api/xgboost/v1alpha1/v1alpha1_suite_test.go
+++ b/api/xgboost/v1alpha1/v1alpha1_suite_test.go
@@ -18,37 +18,23 @@ package v1alpha1
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 var c client.Client
 
 func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
-	}
-
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	if _, err = t.Start(); err != nil {
 		log.Fatal(err)
 	}
 
 	c = fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	code := m.Run()
-	err = t.Stop()
-	if err != nil {
-		log.Fatal(err)
-	}
 	os.Exit(code)
 }

--- a/controllers/suite_tests/suite_test.go
+++ b/controllers/suite_tests/suite_test.go
@@ -17,31 +17,24 @@ limitations under the License.
 package suite_tests
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/alibaba/kubedl/api"
-	"github.com/alibaba/kubedl/controllers"
-	"github.com/alibaba/kubedl/pkg/job_controller"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	// +kubebuilder:scaffold:imports
 )
 
-var cfg *rest.Config
-var k8sManager controllerruntime.Manager
 var k8sClient client.Client
-var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -58,35 +51,13 @@ var _ = BeforeSuite(func(done Done) {
 	}))
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
-	}
 
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
-
-	err = api.AddToScheme(scheme.Scheme)
+	err := api.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sManager, err = controllerruntime.NewManager(cfg, controllerruntime.Options{
-		Scheme: scheme.Scheme,
-	})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(k8sManager).ToNot(BeNil())
-
-	err = controllers.SetupWithManager(k8sManager, job_controller.JobControllerConfiguration{})
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		err = k8sManager.Start(controllerruntime.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred())
-	}()
-
-	k8sClient = k8sManager.GetClient()
+	k8sClient = fake.NewFakeClientWithScheme(scheme.Scheme)
 	Expect(k8sClient).ToNot(BeNil())
 
 	close(done)
@@ -95,6 +66,4 @@ var _ = BeforeSuite(func(done Done) {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
 })


### PR DESCRIPTION
1. add travis CI config file(worked in my repo)
2. update some suite tests to use fake client instead of control pane, because it rely on some kubebuilder binary files.

fix #18 