### PR TITLE
give resources to the init container of launcher pod of mpijob

### DIFF
--- a/controllers/mpi/mpijob_controller.go
+++ b/controllers/mpi/mpijob_controller.go
@@ -55,6 +55,8 @@ func init() {
 const (
 	controllerName              = "MPIController"
 	defaultKubectlDeliveryImage = "kubedl/kubectl-delivery:latest"
+	initContainerCpu            = "100m"
+	initContainerMem            = "128Mi"
 )
 
 var (
@@ -314,8 +316,8 @@ func (r *MPIJobReconciler) setupMPILauncher(mpiJob *training.MPIJob, podTemplate
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("0"),
-				corev1.ResourceMemory: resource.MustParse("0"),
+				corev1.ResourceCPU:    resource.MustParse(initContainerCpu),
+				corev1.ResourceMemory: resource.MustParse(initContainerMem),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Hi kubeDL team,
  I find that the resources giving to the  init container of launcher pod of mpijob is zero. It seems unreasonable. I refers to [mpi-operator](https://github.com/kubeflow/mpi-operator/blob/master/pkg/controllers/v1/mpi_job_controller.go) to give the init container a reasonable resources.
  Looking forward to your reply.