### PR TITLE
remove isGPULauncher variable, directly replace it with launcherRunsWorkload

### DIFF
--- a/controllers/mpi/pod.go
+++ b/controllers/mpi/pod.go
@@ -29,8 +29,6 @@ import (
 	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	"github.com/alibaba/kubedl/pkg/util"
 	"github.com/alibaba/kubedl/pkg/util/k8sutil"
-	"github.com/alibaba/kubedl/pkg/util/quota"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,10 +58,8 @@ func (r *MPIJobReconciler) GetPodsForJob(obj interface{}) ([]*corev1.Pod, error)
 		// MPIJob ensures job-attached configuration is kept by ConfigMap when launcher
 		// neither succeed nor failed.
 		if pod.Labels[apiv1.ReplicaTypeLabel] == strings.ToLower(string(mpiv1.MPIReplicaTypeLauncher)) && k8sutil.IsPodActive(pod) {
-			isGPULauncher := quota.PodRequestsForGPU(pod) && launcherRunsWorkload
-
 			klog.Info("launcher of MPIJob: ", mpiJob.Namespace+"/"+mpiJob.Name, "generate job config.")
-			_, err := r.getOrCreateJobConfig(mpiJob, workerReplicas, isGPULauncher)
+			_, err := r.getOrCreateJobConfig(mpiJob, workerReplicas, launcherRunsWorkload)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/util/quota/resources.go
+++ b/pkg/util/quota/resources.go
@@ -7,10 +7,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-const (
-	ResourceNvidiaGPU = "nvidia.com/gpu"
-)
-
 // SumUpContainersResources sum up resources aggregated from containers list.
 func SumUpContainersResources(containers []v1.Container) v1.ResourceRequirements {
 	sum := v1.ResourceRequirements{
@@ -54,20 +50,4 @@ func GetPodResourceRequest(pod *v1.Pod) v1.ResourceList {
 		result = quota.Add(result, pod.Spec.Overhead)
 	}
 	return result
-}
-
-func PodRequestsForGPU(pod *v1.Pod) bool {
-	hasGPU := func(res v1.ResourceRequirements) bool {
-		_, ok1 := res.Requests[ResourceNvidiaGPU]
-		_, ok2 := res.Limits[ResourceNvidiaGPU]
-		return ok1 || ok2
-	}
-
-	for i := range pod.Spec.Containers {
-		c := &pod.Spec.Containers[i]
-		if hasGPU(c.Resources) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
isGPULauncher has a problem, which is it only support nvidia gpu resources. If I want to support other gpu resources, it does not work. I think just directly use launcherRunsWorkload to decide whether launcher runs workload is ok. Actually it leaves to the users to make a decision. And the default behavior is launcher runs workload.

Looking forward to your advice!

### II. Does this pull request fix one issue?
No

### III. Special notes for reviewers if any.


