### PR TITLE
fix: self-dependency in DAG-MPI and re-correct job config creation position.

### DIFF
--- a/apis/training/v1alpha1/mpijob_default.go
+++ b/apis/training/v1alpha1/mpijob_default.go
@@ -75,7 +75,7 @@ func setDefaultMPIDAGConditions(job *MPIJob) {
 	if job.Spec.MPIReplicaSpecs[MPIReplicaTypeWorker] != nil &&
 		job.Spec.MPIReplicaSpecs[MPIReplicaTypeLauncher] != nil {
 		job.Spec.MPIReplicaSpecs[MPIReplicaTypeLauncher].DependOn = []v1.DAGCondition{
-			{Upstream: MPIReplicaTypeLauncher, OnPhase: corev1.PodRunning},
+			{Upstream: MPIReplicaTypeWorker, OnPhase: corev1.PodRunning},
 		}
 	}
 }

--- a/controllers/mpi/pod.go
+++ b/controllers/mpi/pod.go
@@ -19,18 +19,14 @@ package mpi
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/controller"
 
 	mpiv1 "github.com/alibaba/kubedl/apis/training/v1alpha1"
 	"github.com/alibaba/kubedl/pkg/job_controller"
-	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	"github.com/alibaba/kubedl/pkg/util"
-	"github.com/alibaba/kubedl/pkg/util/k8sutil"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,10 +38,6 @@ func (r *MPIJobReconciler) GetPodsForJob(obj interface{}) ([]*corev1.Pod, error)
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: r.ctrl.GenLabels(mpiJob.GetName()),
 	})
-	workerReplicas := int32(0)
-	if workerSpec := mpiJob.Spec.MPIReplicaSpecs[mpiv1.MPIReplicaTypeWorker]; workerSpec != nil && workerSpec.Replicas != nil {
-		workerReplicas = *workerSpec.Replicas
-	}
 	// List all pods to include those that don't match the selector anymore
 	// but have a ControllerRef pointing to this controller.
 	podlist := &corev1.PodList{}
@@ -54,17 +46,6 @@ func (r *MPIJobReconciler) GetPodsForJob(obj interface{}) ([]*corev1.Pod, error)
 		return nil, err
 	}
 	pods := util.ToPodPointerList(podlist.Items)
-	for _, pod := range pods {
-		// MPIJob ensures job-attached configuration is kept by ConfigMap when launcher
-		// neither succeed nor failed.
-		if pod.Labels[apiv1.ReplicaTypeLabel] == strings.ToLower(string(mpiv1.MPIReplicaTypeLauncher)) && k8sutil.IsPodActive(pod) {
-			klog.Info("launcher of MPIJob: ", mpiJob.Namespace+"/"+mpiJob.Name, "generate job config.")
-			_, err := r.getOrCreateJobConfig(mpiJob, workerReplicas, launcherRunsWorkload)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 	// If any adoptions are attempted, we should first recheck for deletion
 	// with an uncached quorum read sometime after listing Pods (see #42639).
 	canAdoptFunc := job_controller.RecheckDeletionTimestamp(func() (metav1.Object, error) {


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. fix Launcher self-dependency in DAG-MPI mode.
2. re-correct job config creation position in control flow.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #164 

### III. Special notes for reviewers if any.


