### PR TITLE
typo: remove redundancy code

### DIFF
--- a/pkg/job_controller/job.go
+++ b/pkg/job_controller/job.go
@@ -302,7 +302,6 @@ func (jc *JobController) ReconcileJobs(job interface{}, replicas map[apiv1.Repli
 			result.Requeue = true
 			return result, nil
 		}
-		return result, jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)
 	}
 	return result, nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
The code that I remove is redundancy. Besides, it logs an error like
`2021-09-22T11:34:19.459Z        ERROR   controller      Reconciler error        {"controller": "MPIController", "name": "mpi-demo", "namespace": "kubedl", "error": "Operation cannot be fulfilled on mpijobs.training.kubedl.io \"mpi-demo\": the object has been modified; please apply your changes to the latest version and try again"}`


### II. Does this pull request fix one issue?
No

### III. Special notes for reviewers if any.
No

