### PR TITLE
Update GenGeneralName func

### DIFF
--- a/controllers/mpi/mpi_config.go
+++ b/controllers/mpi/mpi_config.go
@@ -83,7 +83,7 @@ shift
 	}
 	var buffer bytes.Buffer
 	if launcherRunsWorkload {
-		buffer.WriteString(fmt.Sprintf("%s%s slots=%d\n", mpiJob.Name, launcherSuffix, slots))
+		buffer.WriteString(fmt.Sprintf("%s%s-0 slots=%d\n", mpiJob.Name, launcherSuffix, slots))
 	}
 	for i := 0; i < int(workerReplicas); i++ {
 		// If MPIDistributionType specified, the format of the hostfile file is inconsistent as


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
I found a bug in mpijob. 
https://github.com/kubedl-io/kubedl/blob/8e231e86dc82bc80c6e044d8dd9f385100277f75/controllers/mpi/mpi_config.go#L85-L87
(a)These codes write hostfile data in configmap. It writes {mpiJob.Name}-launcher slots=1

https://github.com/kubedl-io/kubedl/blob/8e231e86dc82bc80c6e044d8dd9f385100277f75/pkg/util/util.go#L74-L77
(b)These codes decide the mpijob launcher podName. The name is {mpiJob.Name}-launcher-0

(a) and (b) conflicts.

Why do I change (b) to (a)?
Although I do not know how the kubedl/kubectl-delivery:latest was built. I guess that it's source code from
https://github.com/kubeflow/mpi-operator/blob/c5c0c3ef99ec9de948600766988ea7134d3d2af6/cmd/kubectl-delivery/app/server.go#L120. From this code, I know that kubectl-delivery use the (a) form. So I change (b) to (a)

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### III. Special notes for reviewers if any.
**Please have an attention. I just focus on mpijob. I am not 100 percent sure that this PR does not influence others operators. Please review it's influence.** 

