### PR TITLE
update rbac about volcano

### DIFF
--- a/config/manager/all_in_one.yaml
+++ b/config/manager/all_in_one.yaml
@@ -8,7 +8,6 @@ kind: Namespace
 metadata:
   name: kubedl-system
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -200,6 +199,15 @@ rules:
       - update
       - watch
   - apiGroups:
+      - scheduling.incubator.k8s.io
+      - scheduling.sigs.dev
+      - scheduling.volcano.sh
+    resources:
+      - podgroups
+      - queues
+    verbs:
+      - '*'
+  - apiGroups:
       - serving.kubedl.io
     resources:
       - inferences
@@ -359,7 +367,6 @@ rules:
       - get
       - patch
       - update
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -191,6 +191,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  - scheduling.volcano.sh
+  resources:
+  - podgroups
+  - queues
+  verbs:
+  - '*'
+- apiGroups:
   - serving.kubedl.io
   resources:
   - inferences

--- a/controllers/elasticdl/elasticdljob_controller.go
+++ b/controllers/elasticdl/elasticdljob_controller.go
@@ -73,6 +73,7 @@ type ElasticDLJobReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=elasticdljobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=elasticdljobs/status,verbs=get;update;patch
 

--- a/controllers/mars/marsjob_controller.go
+++ b/controllers/mars/marsjob_controller.go
@@ -80,6 +80,7 @@ type MarsJobReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=marsjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=marsjobs/status,verbs=get;update;patch
 

--- a/controllers/mpi/mpijob_controller.go
+++ b/controllers/mpi/mpijob_controller.go
@@ -98,6 +98,7 @@ type MPIJobReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=mpijobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=mpijobs/status,verbs=get;update;patch
 

--- a/controllers/pytorch/pytorchjob_controller.go
+++ b/controllers/pytorch/pytorchjob_controller.go
@@ -96,6 +96,7 @@ func (r *PytorchJobReconciler) GetNodeForModelOutput(pods []*corev1.Pod) (nodeNa
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=pytorchjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=pytorchjobs/status,verbs=get;update;patch
 

--- a/controllers/tensorflow/tfjob_controller.go
+++ b/controllers/tensorflow/tfjob_controller.go
@@ -127,6 +127,7 @@ func (r *TFJobReconciler) GetNodeForModelOutput(pods []*corev1.Pod) string {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;create;patch;
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=tfjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=tfjobs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/xdl/xdljob_controller.go
+++ b/controllers/xdl/xdljob_controller.go
@@ -91,6 +91,7 @@ type XDLJobReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=xdljobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=xdljobs/status,verbs=get;update;patch
 

--- a/controllers/xgboost/xgboostjob_controller.go
+++ b/controllers/xgboost/xgboostjob_controller.go
@@ -79,6 +79,7 @@ type XgboostJobReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups=scheduling.incubator.k8s.io;scheduling.sigs.dev;scheduling.volcano.sh,resources=podgroups;queues,verbs=*
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=xgboostjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=training.kubedl.io,resources=xgboostjobs/status,verbs=get;update;patch
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR adds the volcano permission to rbac, it could be consider a patch of https://github.com/kubedl-io/kubedl/pull/161

The rbac contents refer to https://github.com/kubeflow/mpi-operator/blob/c5c0c3ef99ec9de948600766988ea7134d3d2af6/deploy/v1/mpi-operator.yaml#L142-L150 and I have tested it.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### III. Special notes for reviewers if any.
I just add the volcano permission to rbac. But the batch-scheduler and coscheduler should also add the related permission.

