### PR TITLE
feat(inference): inject defaulter-gen functions into scheme.

### DIFF
--- a/apis/serving/v1alpha1/inference_types.go
+++ b/apis/serving/v1alpha1/inference_types.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:subresource:status
+// +k8s:defaulter-gen=true
 
 // Inference is the Schema for the inference API.
 type Inference struct {

--- a/apis/serving/v1alpha1/zz_generated.defaults.go
+++ b/apis/serving/v1alpha1/zz_generated.defaults.go
@@ -27,5 +27,10 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&Inference{}, func(obj interface{}) { SetObjectDefaults_Inference(obj.(*Inference)) })
 	return nil
+}
+
+func SetObjectDefaults_Inference(in *Inference) {
+	SetDefaults_Inference(in)
 }


### PR DESCRIPTION
Signed-off-by: SimonCqk <cqk0100@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

inject defaulter functions into scheme and invoke defaulter hooks before reconcile inference object.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


