### PR TITLE
add DeleteExpectations func and call it when job is delete

### DIFF
--- a/controllers/elasticdl/elasticdljob_controller.go
+++ b/controllers/elasticdl/elasticdljob_controller.go
@@ -125,6 +125,7 @@ func (r *ElasticDLJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &training.ElasticDLJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/elasticdl/status.go
+++ b/controllers/elasticdl/status.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alibaba/kubedl/pkg/job_controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -133,6 +134,17 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(e event.CreateEvent) bool {
 			return false
 		}
 		reconciler.ctrl.Metrics.CreatedInc()
+		return true
+	}
+}
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		elasticdlJob, ok := e.Meta.(*training.ElasticDLJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(elasticdlJob, elasticdlJob.Spec.ElasticDLReplicaSpecs)
 		return true
 	}
 }

--- a/controllers/mars/marsjob_controller.go
+++ b/controllers/mars/marsjob_controller.go
@@ -135,6 +135,7 @@ func (r *MarsJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resources with create event filter.
 	if err = c.Watch(&source.Kind{Type: &kubedliov1beta1.MarsJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/mars/status.go
+++ b/controllers/mars/status.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/alibaba/kubedl/apis/training/v1alpha1"
+	"github.com/alibaba/kubedl/pkg/job_controller"
 	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	commonutil "github.com/alibaba/kubedl/pkg/util"
 
@@ -145,6 +146,17 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(e event.CreateEvent) bool {
 			return false
 		}
 		reconciler.ctrl.Metrics.CreatedInc()
+		return true
+	}
+}
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		marsJob, ok := e.Meta.(*v1alpha1.MarsJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(marsJob, marsJob.Spec.MarsReplicaSpecs)
 		return true
 	}
 }

--- a/controllers/mpi/job.go
+++ b/controllers/mpi/job.go
@@ -208,3 +208,14 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(e event.CreateEvent) bool {
 		return true
 	}
 }
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		mpiJob, ok := e.Meta.(*training.MPIJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(mpiJob, mpiJob.Spec.MPIReplicaSpecs)
+		return true
+	}
+}

--- a/controllers/mpi/mpijob_controller.go
+++ b/controllers/mpi/mpijob_controller.go
@@ -166,6 +166,7 @@ func (r *MPIJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &training.MPIJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/pytorch/pytorchjob_controller.go
+++ b/controllers/pytorch/pytorchjob_controller.go
@@ -148,6 +148,7 @@ func (r *PytorchJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &training.PyTorchJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/pytorch/status.go
+++ b/controllers/pytorch/status.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alibaba/kubedl/pkg/job_controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -141,6 +142,17 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(e event.CreateEvent) bool {
 			return false
 		}
 		reconciler.ctrl.Metrics.CreatedInc()
+		return true
+	}
+}
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		pytorchJob, ok := e.Meta.(*training.PyTorchJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(pytorchJob, pytorchJob.Spec.PyTorchReplicaSpecs)
 		return true
 	}
 }

--- a/controllers/tensorflow/status.go
+++ b/controllers/tensorflow/status.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	training "github.com/alibaba/kubedl/apis/training/v1alpha1"
+	"github.com/alibaba/kubedl/pkg/job_controller"
 	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	commonutil "github.com/alibaba/kubedl/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,17 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(event.CreateEvent) bool {
 		}
 		log.Info(msg)
 		reconciler.ctrl.Metrics.CreatedInc()
+		return true
+	}
+}
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		tfJob, ok := e.Meta.(*training.TFJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(tfJob, tfJob.Spec.TFReplicaSpecs)
 		return true
 	}
 }

--- a/controllers/tensorflow/tfjob_controller.go
+++ b/controllers/tensorflow/tfjob_controller.go
@@ -193,6 +193,7 @@ func (r *TFJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &training.TFJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/xdl/status.go
+++ b/controllers/xdl/status.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/alibaba/kubedl/pkg/job_controller"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -53,6 +54,17 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(event.CreateEvent) bool {
 			return false
 		}
 		reconciler.ctrl.Metrics.CreatedInc()
+		return true
+	}
+}
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		xdlJob, ok := e.Meta.(*xdlv1alpha1.XDLJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(xdlJob, xdlJob.Spec.XDLReplicaSpecs)
 		return true
 	}
 }

--- a/controllers/xdl/xdljob_controller.go
+++ b/controllers/xdl/xdljob_controller.go
@@ -145,6 +145,7 @@ func (r *XDLJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &xdlv1alpha1.XDLJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}

--- a/controllers/xgboost/job.go
+++ b/controllers/xgboost/job.go
@@ -222,3 +222,14 @@ func onOwnerCreateFunc(r reconcile.Reconciler) func(event.CreateEvent) bool {
 		return true
 	}
 }
+
+func OnOwnerDeleteAndDeletionExpectationFunc(jc job_controller.JobController) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		xgboostJob, ok := e.Meta.(*v1alpha1.XGBoostJob)
+		if !ok {
+			return false
+		}
+		jc.DeleteExpectations(xgboostJob, xgboostJob.Spec.XGBReplicaSpecs)
+		return true
+	}
+}

--- a/controllers/xgboost/xgboostjob_controller.go
+++ b/controllers/xgboost/xgboostjob_controller.go
@@ -132,6 +132,7 @@ func (r *XgboostJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch owner resource with create event filter.
 	if err = c.Watch(&source.Kind{Type: &v1alpha1.XGBoostJob{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		CreateFunc: onOwnerCreateFunc(r),
+		DeleteFunc: OnOwnerDeleteAndDeletionExpectationFunc(r.ctrl),
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

add DeleteExpectations func and call it when job is delete

The detail story is below:
I deploy a mpijob using myself version(it is a little different with the official version, but it doesn't matter), but I forget to creating the rbac before, so the launcher pod doesn't create, then I delete the mpijob and create the rbac, and create the same mpijob again. The result is mpijob is created but there are no any pods created. And I found the following log. Then I check the source code and open this PR.

```
2021-10-20T11:42:12.486Z        INFO    mpi-controller  reconcile cancelled, job does not need to do reconcile or has been deleted        {"job namespace": "kubedl", "job name": "mpi-demo", "need sync": false, "deleted": false}
2021-10-20T11:42:12.486Z        DEBUG   controller      Successfully Reconciled {"controller": "MPIController", "name": "mpi-demo", "namespace": "kubedl"}
2021-10-20T11:42:12.488Z        INFO    mpi-controller  reconcile cancelled, job does not need to do reconcile or has been deleted        {"job namespace": "kubedl", "job name": "mpi-demo", "need sync": false, "deleted": false}
2021-10-20T11:42:12.488Z        DEBUG   controller      Successfully Reconciled {"controller": "MPIController", "name": "mpi-demo", "namespace": "kubedl"}
```


