### PR TITLE
refactor(mpi): remove global launcherRunsWorkload flag.

### DIFF
--- a/controllers/mpi/mpijob_controller.go
+++ b/controllers/mpi/mpijob_controller.go
@@ -49,7 +49,6 @@ import (
 
 func init() {
 	pflag.StringVar(&kubectlDeliveryImage, "kubectl-delivery-image", defaultKubectlDeliveryImage, "utility image to delivery kubectl binary")
-	pflag.BoolVar(&launcherRunsWorkload, "launcher-runs-workloads", true, "Set launcher run the workload when launcher has GPU")
 }
 
 const (
@@ -63,7 +62,6 @@ var (
 	log = logf.Log.WithName("mpi-controller")
 
 	kubectlDeliveryImage string
-	launcherRunsWorkload bool
 )
 
 // NewReconciler returns a new reconcile.Reconciler
@@ -221,14 +219,16 @@ func (r *MPIJobReconciler) SetClusterSpec(ctx context.Context, job interface{}, 
 	if workerSpec := mpiJob.Spec.MPIReplicaSpecs[training.MPIReplicaTypeWorker]; workerSpec != nil && workerSpec.Replicas != nil {
 		workerReplicas = *workerSpec.Replicas
 	}
+	launcherRunsWorkload := false
 	if launcherSpec, ok := mpiJob.Spec.MPIReplicaSpecs[training.MPIReplicaTypeLauncher]; ok && launcherSpec != nil {
-		// MPIJob ensures job-attached configuration is kept by ConfigMap when launcher
-		// neither succeed nor failed.
-		log.Info("launcher of MPIJob: ", mpiJob.Namespace+"/"+mpiJob.Name, " generate job config.")
-		_, err := r.getOrCreateJobConfig(mpiJob, workerReplicas, launcherRunsWorkload)
-		if err != nil {
-			return err
-		}
+		launcherRunsWorkload = true
+	}
+	// MPIJob ensures job-attached configuration is kept by ConfigMap when launcher
+	// neither succeed nor failed.
+	log.Info("launcher of MPIJob: ", mpiJob.Namespace+"/"+mpiJob.Name, " generate job config.")
+	_, err := r.getOrCreateJobConfig(mpiJob, workerReplicas, launcherRunsWorkload)
+	if err != nil {
+		return err
 	}
 
 	switch rt {


### PR DESCRIPTION
Signed-off-by: SimonCqk <cqk0100@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

remove `launcherRunsWorkload` global startup flag, which can be inferred by whether has `Launcher` role in job spec.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #194 

### III. Special notes for reviewers if any.


