### PR TITLE
fix: check pod failed reason for failover

### DIFF
--- a/pkg/job_controller/job_test.go
+++ b/pkg/job_controller/job_test.go
@@ -6,18 +6,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alibaba/kubedl/cmd/options"
-	"github.com/alibaba/kubedl/pkg/metrics"
-
-	"github.com/alibaba/kubedl/apis/model/v1alpha1"
-	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
-	"github.com/alibaba/kubedl/pkg/test_job/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/alibaba/kubedl/apis/model/v1alpha1"
+	"github.com/alibaba/kubedl/cmd/options"
+	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
+	"github.com/alibaba/kubedl/pkg/metrics"
+	"github.com/alibaba/kubedl/pkg/test_job/v1"
 )
 
 func TestDeletePodsAndServices(T *testing.T) {
@@ -289,6 +289,13 @@ func newPod(name string, phase corev1.PodPhase) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "default-container",
+				},
+			},
 		},
 		Status: corev1.PodStatus{
 			Phase: phase,

--- a/pkg/job_controller/pod.go
+++ b/pkg/job_controller/pod.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,8 +38,6 @@ import (
 	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	commonutil "github.com/alibaba/kubedl/pkg/util"
 	trainutil "github.com/alibaba/kubedl/pkg/util/train"
-	"github.com/golang/glog"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -303,7 +303,8 @@ func (jc *JobController) ReconcilePods(
 
 			// Check if the pod is retryable.
 			if spec.RestartPolicy == apiv1.RestartPolicyExitCode {
-				if pod.Status.Phase == v1.PodFailed && trainutil.IsRetryableExitCode(exitCode) {
+				if pod.Status.Phase == v1.PodFailed &&
+					(trainutil.IsRetryableExitCode(exitCode) || trainutil.IsRetryablePodFailedReason(pod.Status.Reason)) {
 					logger.Infof("Need to restart the pod: %v.%v", pod.Namespace, pod.Name)
 					runtimeJob, ok := job.(runtime.Object)
 					if !ok {

--- a/pkg/job_controller/pod_test.go
+++ b/pkg/job_controller/pod_test.go
@@ -3,10 +3,11 @@ package job_controller
 import (
 	"testing"
 
+	"k8s.io/api/core/v1"
+
 	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 	testjobv1 "github.com/alibaba/kubedl/pkg/test_job/v1"
 	testutilv1 "github.com/alibaba/kubedl/pkg/test_util/v1"
-	"k8s.io/api/core/v1"
 )
 
 func TestSetRestartPolicy(t *testing.T) {

--- a/pkg/util/train/train_util.go
+++ b/pkg/util/train/train_util.go
@@ -15,6 +15,10 @@
 // Package that various helper routines for training.
 package train
 
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
 func IsRetryableExitCode(exitCode int32) bool {
 	if exitCode == 1 || exitCode == 2 || exitCode == 126 ||
 		exitCode == 127 || exitCode == 128 || exitCode == 139 {
@@ -50,4 +54,12 @@ func IsRetryableExitCode(exitCode int32) bool {
 
 	// We make no guarantee for other exit status. Currently handling them same as permanent errors.
 	return false
+}
+
+// failed pod due to certain reasons is retryable, i.e., rescheduled to resume the job
+func IsRetryablePodFailedReason(reason string) bool {
+	return sets.NewString(
+		// potential pod failed known reasons that can be fail-overed.
+		"OOMKilled", "Killed", "Evicted",
+	).Has(reason)
 }

--- a/pkg/util/train/train_util_test.go
+++ b/pkg/util/train/train_util_test.go
@@ -50,3 +50,38 @@ func TestIsRetryableExitCode(t *testing.T) {
 		}
 	}
 }
+
+func TestIsRetryableReason(t *testing.T) {
+	tcs := []struct {
+		reason   string
+		expected bool
+	}{
+		{
+			reason:   "Error",
+			expected: false,
+		},
+		{
+			reason:   "OOMKilled",
+			expected: true,
+		},
+		{
+			reason:   "Killed",
+			expected: true,
+		},
+		{
+			reason:   "Evicted",
+			expected: true,
+		},
+		{
+			reason:   "Unknown",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		actual := IsRetryablePodFailedReason(tc.reason)
+		if actual != tc.expected {
+			t.Errorf("Reason %s: Expected %t, got %t", tc.reason, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Check pod failed reasons for failover, e.g., OOMKilled, Evicted and Killed. 


### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


