### PR TITLE
adjust the location of creating gang

### DIFF
--- a/pkg/job_controller/job.go
+++ b/pkg/job_controller/job.go
@@ -96,13 +96,6 @@ func (jc *JobController) ReconcileJobs(job interface{}, replicas map[apiv1.Repli
 		jc.BackoffStatesQueue.Forget(jobKey)
 	}()
 
-	if jc.Config.EnableGangScheduling {
-		log.Infof("gang schedule enabled, start to syncing for job %s", jobKey)
-		if _, err = jc.CreateGang(metaObject, replicas); err != nil {
-			return result, err
-		}
-	}
-
 	oldStatus := jobStatus.DeepCopy()
 
 	err = code_sync.InjectCodeSyncInitContainers(metaObject, replicas)
@@ -236,6 +229,13 @@ func (jc *JobController) ReconcileJobs(job interface{}, replicas map[apiv1.Repli
 			return result, jc.Controller.UpdateJobStatusInApiServer(job, &jobStatus)
 		}
 		return result, nil
+	}
+
+	if jc.Config.EnableGangScheduling {
+		log.Infof("gang schedule enabled, start to syncing for job %s", jobKey)
+		if _, err = jc.CreateGang(metaObject, replicas); err != nil {
+			return result, err
+		}
 	}
 
 	// Save the current state of the replicas


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
```
Dec 9, 2021 @ 23:30:13.013 I1209 15:30:13.013155 1 job_controller.go:165] Deleting GangSchedule mpi-demo
Dec 9, 2021 @ 23:30:13.004 time="2021-12-09T15:30:13Z" level=info msg="Ignoring inactive pod default/mpi-demo-worker-0 in state Succeeded, deletion time N/A"
Dec 9, 2021 @ 23:30:13.003 I1209 15:30:13.003808 1 job_controller.go:148] gang schedule created, job name: mpi-demo ,scheduler name: volcano
Dec 9, 2021 @ 23:30:12.999 I1209 15:30:12.999139 1 job.go:86] Reconciling for job mpi-demo
```
Here are logs of my kubedl, the mpi-demo job succeed a few hours before Dec 9, 2021 @ 23:30:12.999, it reconciled for some reason. Authough it has beed succeed, the location of creating gang produced these logs, so I think the location of creating gang should be adjusted.

@SimonCqk @jian-he 

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


