### PR TITLE
feat: specify available host port range for hostnetwork-enabled jobs.

### DIFF
--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
 )
 
 var (
@@ -43,6 +44,9 @@ type JobControllerConfiguration struct {
 
 	// Name of global default gang scheduler.
 	GangSchedulerName string
+
+	// HostNetworkPortRange specifies host ports range to randomize for hostnetwork-enabled jobs.
+	HostNetworkPortRange net.PortRange
 
 	// The container builder image name, Kaniko image
 	ModelImageBuilder string

--- a/controllers/pytorch/pytorchjob_controller.go
+++ b/controllers/pytorch/pytorchjob_controller.go
@@ -216,6 +216,9 @@ func (r *PytorchJobReconciler) SetClusterSpec(ctx context.Context, job interface
 			return fmt.Errorf("invalid config: There should be only a single master with index=0")
 		}
 		masterAddr = "localhost"
+		if hostPort, ok := job_controller.GetHostNetworkPortFromContext(ctx, rtype, index); ok && job_controller.EnableHostNetwork(pytorchJob) {
+			masterPort = hostPort
+		}
 	} else {
 		rank++
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"os"
 
+	"k8s.io/apimachinery/pkg/util/net"
+
 	"github.com/alibaba/kubedl/pkg/features"
 
 	"github.com/spf13/pflag"
@@ -51,9 +53,10 @@ func init() {
 
 func main() {
 	var (
-		ctrlMetricsAddr      string
-		metricsAddr          int
 		enableLeaderElection bool
+		metricsAddr          int
+		ctrlMetricsAddr      string
+		hostPortRange        string
 	)
 	pflag.StringVar(&ctrlMetricsAddr, "controller-metrics-addr", ":8080", "The address the controller metric endpoint binds to.")
 	pflag.IntVar(&metricsAddr, "metrics-addr", 8443, "The address the default endpoints binds to.")
@@ -62,11 +65,12 @@ func main() {
 	pflag.StringVar(&options.CtrlConfig.GangSchedulerName, "gang-scheduler-name", "", "specify the name of gang scheduler")
 	pflag.IntVar(&options.CtrlConfig.MaxConcurrentReconciles, "max-reconciles", 1, "specify the number of max concurrent reconciles of each controller")
 	pflag.StringVar(&options.CtrlConfig.ModelImageBuilder, "model-image-builder", "kubedl/kaniko:latest", "The image name of container builder for building the model image")
-
+	pflag.StringVar(&hostPortRange, "hostnetwork-port-range", "20000-30000", "hostnetwork port range for hostnetwork-enabled jobs")
 	features.KubeDLFeatureGates.AddFlag(pflag.CommandLine)
 	pflag.Parse()
 
 	options.CtrlConfig.EnableGangScheduling = options.CtrlConfig.GangSchedulerName != ""
+	options.CtrlConfig.HostNetworkPortRange = *net.ParsePortRangeOrDie(hostPortRange)
 
 	if options.CtrlConfig.MaxConcurrentReconciles <= 0 {
 		options.CtrlConfig.MaxConcurrentReconciles = 1


### PR DESCRIPTION
Signed-off-by: SimonCqk <cqk0100@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. support specifying host port range for hostnetwork enabled jobs.
2. bugfix for pytorchjob in hostnetwork mode.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


