### PR TITLE
support spot replica

### DIFF
--- a/config/crd/bases/training.kubedl.io_elasticdljobs.yaml
+++ b/config/crd/bases/training.kubedl.io_elasticdljobs.yaml
@@ -57,6 +57,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_marsjobs.yaml
+++ b/config/crd/bases/training.kubedl.io_marsjobs.yaml
@@ -57,6 +57,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_mpijobs.yaml
+++ b/config/crd/bases/training.kubedl.io_mpijobs.yaml
@@ -69,6 +69,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_pytorchjobs.yaml
+++ b/config/crd/bases/training.kubedl.io_pytorchjobs.yaml
@@ -144,6 +144,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_tfjobs.yaml
+++ b/config/crd/bases/training.kubedl.io_tfjobs.yaml
@@ -152,6 +152,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_xdljobs.yaml
+++ b/config/crd/bases/training.kubedl.io_xdljobs.yaml
@@ -72,6 +72,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/config/crd/bases/training.kubedl.io_xgboostjobs.yaml
+++ b/config/crd/bases/training.kubedl.io_xgboostjobs.yaml
@@ -66,6 +66,18 @@ spec:
                       type: integer
                     restartPolicy:
                       type: string
+                    spotReplicaSpec:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        priorityClassName:
+                          type: string
+                        spotReplicaNumber:
+                          format: int32
+                          type: integer
+                      type: object
                     template:
                       properties:
                         metadata:

--- a/pkg/job_controller/api/v1/types.go
+++ b/pkg/job_controller/api/v1/types.go
@@ -80,6 +80,11 @@ type ReplicaSpec struct {
 	// If unspecified, defaults to 1.
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Spot replicas are a subset of Replicas that allow for interruptions. They can use resources with less SLO guarantee.
+	// Spot replicas are suitable for stateless or fault-tolerant jobs.
+	// These replicas can be scheduled with higher chance at lower resource pricing.
+	SpotReplicaSpec *SpotReplicaSpec `json:"spotReplicaSpec,omitempty"`
+
 	// Template is the object that describes the pod that
 	// will be created for this replica. RestartPolicy in PodTemplateSpec
 	// will be overide by RestartPolicy in ReplicaSpec
@@ -95,6 +100,16 @@ type ReplicaSpec struct {
 	// default DependOn based on each framework's requirements. This feature is enabled by default, and can be
 	// disabled with DAGScheduling feature gate.
 	DependOn []DAGCondition `json:"-"`
+}
+
+// SpotReplicaSpec is the differential spec of spot replicas, to override the replica template
+type SpotReplicaSpec struct {
+	// SpotReplicaNumber is the desired number of spot replicas.
+	// If unspecified, SpotReplicaNumber defaults to 0.
+	// By default, replicas with index in the range from (Replicas - SpotReplicaNumber) to (Replicas -1 ) are spot replicas.
+	SpotReplicaNumber int32             `json:"spotReplicaNumber,omitempty"`
+	PriorityClassName string            `json:"priorityClassName,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
 }
 
 // JobCondition describes the state of the job at a certain point.

--- a/pkg/job_controller/api/v1/types.go
+++ b/pkg/job_controller/api/v1/types.go
@@ -102,14 +102,16 @@ type ReplicaSpec struct {
 	DependOn []DAGCondition `json:"-"`
 }
 
-// SpotReplicaSpec is the differential spec of spot replicas, to override the replica template
+// SpotReplicaSpec is the differential spec of spot replicas, to override the replica template.
 type SpotReplicaSpec struct {
 	// SpotReplicaNumber is the desired number of spot replicas.
 	// If unspecified, SpotReplicaNumber defaults to 0.
 	// By default, replicas with index in the range from (Replicas - SpotReplicaNumber) to (Replicas -1 ) are spot replicas.
-	SpotReplicaNumber int32             `json:"spotReplicaNumber,omitempty"`
-	PriorityClassName string            `json:"priorityClassName,omitempty"`
-	Labels            map[string]string `json:"labels,omitempty"`
+	SpotReplicaNumber int32 `json:"spotReplicaNumber,omitempty"`
+	// PriorityClassName is the priorityClassName of spot replicas, to override that in replica template.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// Labels are the extra set of labels to add on the spot replicas, overriding coinciding labels in the replica template if any.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // JobCondition describes the state of the job at a certain point.


### PR DESCRIPTION
Signed-off-by: yyh <yinghao.yyh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Enabling part of replicas to be spot, i.e., to use resources with less SLO guarantee.
Spot replicas are suitable for stateless or fault-tolerant jobs. These replicas can be scheduled with a higher chance at lower resource pricing.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


