### PR TITLE
feat(gang): split gang entities by job role when DAG is enabled.

### DIFF
--- a/pkg/gang_schedule/batch_scheduler/scheduler_test.go
+++ b/pkg/gang_schedule/batch_scheduler/scheduler_test.go
@@ -1,15 +1,17 @@
 package batch_scheduler
 
 import (
-	testjobv1 "github.com/alibaba/kubedl/pkg/test_job/v1"
-	testutilv1 "github.com/alibaba/kubedl/pkg/test_util/v1"
+	"testing"
+
 	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
+
+	testjobv1 "github.com/alibaba/kubedl/pkg/test_job/v1"
+	testutilv1 "github.com/alibaba/kubedl/pkg/test_util/v1"
 )
 
 func TestCreateGang(t *testing.T) {
@@ -25,7 +27,7 @@ func TestCreateGang(t *testing.T) {
 		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
 		testScheduler := &kubeBatchScheduler{client: fakeClient}
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
+		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs, testJob.Spec.RunPolicy.SchedulingPolicy)
 		testPodGroup := testObject.(*v1alpha1.PodGroup)
 		assert.Equal(t, testPodGroup.Name, testutilv1.TestJobName)
 		assert.Equal(t, testPodGroup.Namespace, metav1.NamespaceDefault)
@@ -46,10 +48,10 @@ func TestBindPodToGang(t *testing.T) {
 		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
 		testScheduler := &kubeBatchScheduler{client: fakeClient}
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
+		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs, testJob.Spec.RunPolicy.SchedulingPolicy)
 		testPodGroup := testObject.(*v1alpha1.PodGroup)
 		testPodSpec := testutilv1.NewTestReplicaSpecTemplate()
-		testScheduler.BindPodToGang(&testPodSpec, testPodGroup)
+		testScheduler.BindPodToGang(testJob, &testPodSpec, testPodGroup, "")
 		assert.Equal(t, testPodSpec.Annotations[v1alpha1.GroupNameAnnotationKey], testPodGroup.Name)
 	}
 }

--- a/pkg/gang_schedule/coscheduler/scheduler_test.go
+++ b/pkg/gang_schedule/coscheduler/scheduler_test.go
@@ -1,62 +1,477 @@
 package coscheduler
 
 import (
-	testutilv1 "github.com/alibaba/kubedl/pkg/test_util/v1"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+	"sort"
 	"testing"
 
-	testjobv1 "github.com/alibaba/kubedl/pkg/test_job/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/scheduler-plugins/pkg/apis/scheduling/v1alpha1"
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	"github.com/alibaba/kubedl/apis"
+	trainingv1alpha1 "github.com/alibaba/kubedl/apis/training/v1alpha1"
+	"github.com/alibaba/kubedl/pkg/features"
+	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 )
 
-var (
-	controllerKind = testjobv1.SchemeGroupVersionKind
-)
-
-func TestCreateGang(t *testing.T) {
-	testCases := []int{
-		1, 2, 3, 9,
+func TestCoscheduling_CreateGang(t *testing.T) {
+	tfGVK := schema.GroupVersionKind{
+		Group:   trainingv1alpha1.GroupVersion.Group,
+		Version: trainingv1alpha1.GroupVersion.Version,
+		Kind:    trainingv1alpha1.TFJobKind,
+	}
+	pytorchGVK := schema.GroupVersionKind{
+		Group:   trainingv1alpha1.GroupVersion.Group,
+		Version: trainingv1alpha1.GroupVersion.Version,
+		Kind:    trainingv1alpha1.PyTorchJobKind,
+	}
+	testCases := []struct {
+		name       string
+		job        metav1.Object
+		podgrpoups v1alpha1.PodGroupList
+		dag        bool
+	}{
+		{
+			name:       "input tf job with 1 ps and 1 worker and no run policy",
+			job:        createTFJob("job-1", 1, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-1", "", "job-1", "", 2, metav1.NewControllerRef(createTFJob("job-1", 1, nil), tfGVK))}},
+		},
+		{
+			name:       "input tf job with 1 ps and 3 worker and no run policy",
+			job:        createTFJob("job-2", 3, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-2", "", "job-2", "", 4, metav1.NewControllerRef(createTFJob("job-2", 3, nil), tfGVK))}},
+		},
+		{
+			name: "input tf job with 1 ps and 3 worker and min-available(2) in run policy",
+			job: createTFJob("job-3", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+				MinAvailable: pointer.Int32Ptr(2)}}),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-3", "", "job-3", "", 2,
+				metav1.NewControllerRef(createTFJob("job-3", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+					MinAvailable: pointer.Int32Ptr(2)}}), tfGVK))}},
+		},
+		{
+			name: "input pytorch job with 1 worker and no run policy",
+			job:  createPytorchJob("job-4", 1, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-4", "", "job-4", "", 1, metav1.NewControllerRef(
+				createTFJob("job-4", 1, nil), pytorchGVK))}},
+		},
+		{
+			name: "input pytorch job with 3 worker and no run policy",
+			job:  createPytorchJob("job-5", 3, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-5", "", "job-5", "", 3, metav1.NewControllerRef(
+				createPytorchJob("job-5", 3, nil), pytorchGVK))}},
+		},
+		{
+			name: "input pytorch job with 3 worker and min-available(2) in run policy",
+			job: createPytorchJob("job-6", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+				MinAvailable: pointer.Int32Ptr(2)}}),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-6", "", "job-6", "", 2, metav1.NewControllerRef(
+				createTFJob("job-6", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+					MinAvailable: pointer.Int32Ptr(2)}}), pytorchGVK))}},
+		},
+		{
+			name: "input tf job with ps+worker and dag enabled.",
+			job:  createTFJob("job-7", 1, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{
+				createPodGroup("job-7-ps", "", "job-7", "ps", 1, metav1.NewControllerRef(createTFJob("job-7", 1, nil), tfGVK)),
+				createPodGroup("job-7-worker", "", "job-7", "worker", 1, metav1.NewControllerRef(createTFJob("job-7", 1, nil), tfGVK)),
+			}},
+			dag: true,
+		},
+		{
+			name: "input pytorch job with worker only and dag enabled.",
+			job:  createPytorchJob("job-8", 3, nil),
+			podgrpoups: v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-8-worker", "", "job-8", "worker", 3, metav1.NewControllerRef(
+				createPytorchJob("job-8", 3, nil), pytorchGVK))}},
+			dag: true,
+		},
 	}
 
-	for _, workerNumber := range testCases {
-		scheme := runtime.NewScheme()
-		_ = corev1.AddToScheme(scheme)
-		_ = testjobv1.AddToScheme(scheme)
-		testJob := testutilv1.NewTestJob(workerNumber)
-		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
-		testScheduler := &kubeCoscheduler{client: fakeClient}
+	dagEnabled := features.KubeDLFeatureGates.Enabled(features.DAGScheduling)
+	defer features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): dagEnabled})
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
-		testPodGroup := testObject.(*v1alpha1.PodGroup)
-		assert.Equal(t, testPodGroup.Name, testutilv1.TestJobName)
-		assert.Equal(t, testPodGroup.Namespace, metav1.NamespaceDefault)
-		assert.Equal(t, testPodGroup.Spec.MinMember, int32(workerNumber))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = apis.AddToScheme(scheme)
+			_ = v1alpha1.AddToScheme(scheme)
+			us := kubeCoscheduler{client: fake.NewFakeClientWithScheme(scheme)}
+
+			var (
+				specs     map[v1.ReplicaType]*v1.ReplicaSpec
+				runPolicy *v1.RunPolicy
+			)
+
+			switch testCase.job.(type) {
+			case *trainingv1alpha1.TFJob:
+				specs = testCase.job.(*trainingv1alpha1.TFJob).Spec.TFReplicaSpecs
+				runPolicy = &testCase.job.(*trainingv1alpha1.TFJob).Spec.RunPolicy
+			case *trainingv1alpha1.PyTorchJob:
+				specs = testCase.job.(*trainingv1alpha1.PyTorchJob).Spec.PyTorchReplicaSpecs
+				runPolicy = &testCase.job.(*trainingv1alpha1.PyTorchJob).Spec.RunPolicy
+			default:
+				t.Errorf("unknown test job type: %v", testCase.job)
+				return
+			}
+
+			// only for test
+			features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): testCase.dag})
+
+			gang, err := us.CreateGang(testCase.job, specs, runPolicy.SchedulingPolicy)
+			if err != nil {
+				t.Errorf("failed to create podgrpoups, err: %v", err)
+			}
+
+			gang, err = us.GetGang(types.NamespacedName{Namespace: testCase.job.GetNamespace(), Name: testCase.job.GetName()})
+			if err != nil {
+				t.Errorf("failed to get latest podgrpoups, err: %v", err)
+			}
+			testCase.podgrpoups.TypeMeta = metav1.TypeMeta{Kind: "PodGroupList", APIVersion: "scheduling.sigs.k8s.io/v1alpha1"}
+
+			sort.SliceStable(gang.(*v1alpha1.PodGroupList).Items, func(i, j int) bool {
+				return gang.(*v1alpha1.PodGroupList).Items[i].Name < gang.(*v1alpha1.PodGroupList).Items[j].Name
+			})
+			sort.SliceStable(testCase.podgrpoups.Items, func(i, j int) bool {
+				return testCase.podgrpoups.Items[i].Name < testCase.podgrpoups.Items[j].Name
+			})
+
+			if !equality.Semantic.DeepEqual(gang, &testCase.podgrpoups) {
+				t.Errorf("unexpected podgrpoups result, expected: %+v, got: %+v", &testCase.podgrpoups, gang)
+			}
+		})
 	}
 }
 
-func TestBindPodToGang(t *testing.T) {
-	testCases := []int{
-		1, 2, 3, 9,
+func TestCoscheduling_BindPodToGang(t *testing.T) {
+	testCases := []struct {
+		name         string
+		job          metav1.Object
+		gang         v1alpha1.PodGroupList
+		podSpec      *corev1.PodTemplateSpec
+		rtype        string
+		expectedSpec *corev1.PodTemplateSpec
+		dag          bool
+	}{
+		{
+			name:    "bind pod for tf job ps",
+			job:     createTFJob("job-1", 1, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-1", "12345", "job-1", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "ps",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-1",
+						LabelPodGroupName:         "job-1",
+						LabelPodGroupMinAvailable: "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-1",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job worker(total 1, index 0)",
+			job:     createTFJob("job-2", 1, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-2", "12345", "job-2", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-2",
+						LabelPodGroupName:         "job-2",
+						LabelPodGroupMinAvailable: "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-2",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job worker(total 3, index 1)",
+			job:     createTFJob("job-3", 3, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-3", "12345", "job-3", "", 3, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-3",
+						LabelPodGroupName:         "job-3",
+						LabelPodGroupMinAvailable: "3",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-3",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for pytorch job worker(total 1, index 0)",
+			job:     createPytorchJob("job-4", 1, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-4", "12345", "job-4", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-4",
+						LabelPodGroupName:         "job-4",
+						LabelPodGroupMinAvailable: "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-4",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for pytorch job worker(total 3, index 1)",
+			job:     createPytorchJob("job-5", 3, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-5", "12345", "job-5", "", 3, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-5",
+						LabelPodGroupName:         "job-5",
+						LabelPodGroupMinAvailable: "3",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-5",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job ps and dag enabled",
+			job:     createTFJob("job-6", 1, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-6-ps", "12345", "job-6", "ps", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "ps",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-6-ps",
+						LabelPodGroupName:         "job-6-ps",
+						LabelPodGroupMinAvailable: "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-6-ps",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+			dag: true,
+		},
+		{
+			name:    "bind pod for tf job worker and dag enabled",
+			job:     createTFJob("job-7", 1, nil),
+			gang:    v1alpha1.PodGroupList{Items: []v1alpha1.PodGroup{createPodGroup("job-7-worker", "12345", "job-7", "worker", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelPodGroupIdentity:     "job-7-worker",
+						LabelPodGroupName:         "job-7-worker",
+						LabelPodGroupMinAvailable: "1",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.sigs.k8s.io/v1alpha1",
+							Kind:               "PodGroup",
+							Name:               "job-7-worker",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+			dag: true,
+		},
 	}
 
-	for _, workerNumber := range testCases {
-		scheme := runtime.NewScheme()
-		_ = corev1.AddToScheme(scheme)
-		_ = testjobv1.AddToScheme(scheme)
-		testJob := testutilv1.NewTestJob(workerNumber)
-		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
-		testScheduler := &kubeCoscheduler{client: fakeClient}
+	dagEnabled := features.KubeDLFeatureGates.Enabled(features.DAGScheduling)
+	defer features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): dagEnabled})
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
-		testPodGroup := testObject.(*v1alpha1.PodGroup)
-		testPodSpec := testutilv1.NewTestReplicaSpecTemplate()
-		testScheduler.BindPodToGang(&testPodSpec, testPodGroup)
-		assert.Equal(t, testPodSpec.Labels["pod-group.scheduling.sigs.k8s.io"], testPodGroup.Name)
-		assert.Equal(t, testPodSpec.Labels["pod-group.scheduling.sigs.k8s.io/name"], testPodGroup.Name)
-		assert.Equal(t, testPodSpec.Labels["pod-group.scheduling.sigs.k8s.io/min-available"], string(testPodGroup.Spec.MinMember))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = apis.AddToScheme(scheme)
+			_ = v1beta1.AddToScheme(scheme)
+			us := kubeCoscheduler{client: fake.NewFakeClientWithScheme(scheme)}
+			// only for test
+			features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): testCase.dag})
+			for i := range testCase.gang.Items {
+				testCase.gang.Items[i].TypeMeta = metav1.TypeMeta{APIVersion: "scheduling.sigs.k8s.io/v1alpha1", Kind: "PodGroup"}
+			}
+			err := us.BindPodToGang(testCase.job, testCase.podSpec, &testCase.gang, testCase.rtype)
+			if err != nil {
+				t.Errorf("failed to bind pod to podgrpoups, err: %v", err)
+			}
+			if !equality.Semantic.DeepEqual(testCase.expectedSpec, testCase.podSpec) {
+				t.Errorf("unexpected bind result, expected: %+v, got: %+v", testCase.expectedSpec, testCase.podSpec)
+			}
+		})
 	}
+}
+
+func createTFJob(jobName string, workerReplicas int32, runPolicy *v1.RunPolicy) *trainingv1alpha1.TFJob {
+	job := &trainingv1alpha1.TFJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: trainingv1alpha1.GroupVersion.String(),
+			Kind:       trainingv1alpha1.TFJobKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "default",
+			UID:       "12345",
+		},
+
+		Spec: trainingv1alpha1.TFJobSpec{
+			TFReplicaSpecs: map[v1.ReplicaType]*v1.ReplicaSpec{
+				"PS": {
+					Replicas:      pointer.Int32Ptr(1),
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+				"Worker": {
+					Replicas:      &workerReplicas,
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if runPolicy != nil {
+		job.Spec.RunPolicy = *runPolicy
+	}
+	return job
+}
+
+func createPytorchJob(jobName string, workerReplicas int32, runPolicy *v1.RunPolicy) *trainingv1alpha1.PyTorchJob {
+	job := &trainingv1alpha1.PyTorchJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: trainingv1alpha1.GroupVersion.String(),
+			Kind:       trainingv1alpha1.PyTorchJobKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "default",
+			UID:       "12345",
+		},
+
+		Spec: trainingv1alpha1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[v1.ReplicaType]*v1.ReplicaSpec{
+				"Worker": {
+					Replicas:      &workerReplicas,
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if runPolicy != nil {
+		job.Spec.RunPolicy = *runPolicy
+	}
+	return job
+}
+
+func createPodGroup(name, uid, jobName, rtype string, minMember int32, owner *metav1.OwnerReference) v1alpha1.PodGroup {
+	pg := v1alpha1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "default",
+			ResourceVersion: "1",
+			Labels:          map[string]string{},
+		},
+		Spec: v1alpha1.PodGroupSpec{MinMember: minMember},
+	}
+	if uid != "" {
+		pg.UID = types.UID(uid)
+	}
+	if owner != nil {
+		pg.OwnerReferences = append(pg.OwnerReferences, *owner)
+	}
+	if jobName != "" {
+		pg.Labels[v1.LabelGangSchedulingJobName] = jobName
+	}
+	if rtype != "" {
+		pg.Labels[v1.ReplicaTypeLabel] = rtype
+	}
+	return pg
 }

--- a/pkg/gang_schedule/registry/registry.go
+++ b/pkg/gang_schedule/registry/registry.go
@@ -19,9 +19,10 @@ package registry
 import (
 	"sync"
 
-	"github.com/alibaba/kubedl/pkg/gang_schedule"
 	"k8s.io/klog"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+
+	"github.com/alibaba/kubedl/pkg/gang_schedule"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 func RegisterGangSchedulers(mgr controllerruntime.Manager) {
 	for _, newer := range NewGangSchedulers {
 		scheduler := newer(mgr)
-		klog.Infof("register gang scheduler %s", scheduler.Name())
+		klog.Infof("register gang scheduler %s", scheduler.PluginName())
 		defaultRegistry.Add(scheduler)
 	}
 }
@@ -57,7 +58,7 @@ type Registry struct {
 func (r *Registry) Add(scheduler gang_schedule.GangScheduler) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.registry[scheduler.Name()] = scheduler
+	r.registry[scheduler.PluginName()] = scheduler
 }
 
 func (r *Registry) Get(name string) gang_schedule.GangScheduler {

--- a/pkg/gang_schedule/volcano_scheduler/scheduler.go
+++ b/pkg/gang_schedule/volcano_scheduler/scheduler.go
@@ -2,14 +2,15 @@ package volcano_scheduler
 
 import (
 	"context"
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 
-	"github.com/alibaba/kubedl/apis"
-	"github.com/alibaba/kubedl/pkg/gang_schedule"
-	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
-	"github.com/alibaba/kubedl/pkg/util/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +18,12 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+	"github.com/alibaba/kubedl/apis"
+	"github.com/alibaba/kubedl/pkg/features"
+	"github.com/alibaba/kubedl/pkg/gang_schedule"
+	apiv1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
+	"github.com/alibaba/kubedl/pkg/util/k8sutil"
 )
 
 func init() {
@@ -35,74 +42,171 @@ type volcanoScheduler struct {
 	client client.Client
 }
 
-func (vs *volcanoScheduler) Name() string {
+func (vs *volcanoScheduler) PluginName() string {
 	return "volcano"
 }
 
-func (vs *volcanoScheduler) CreateGang(job metav1.Object, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) (runtime.Object, error) {
-	// Initialize pod group.
-	podGroup := &v1beta1.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      job.GetName(),
-			Namespace: job.GetNamespace(),
-		},
-		Spec: v1beta1.PodGroupSpec{
-			MinMember: k8sutil.GetTotalReplicas(replicas),
-		},
-	}
+func (vs *volcanoScheduler) SchedulerName() string {
+	return "volcano"
+}
+
+func (vs *volcanoScheduler) CreateGang(job metav1.Object, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, schedPolicy *apiv1.SchedulingPolicy) (runtime.Object, error) {
 	// Extract api version and kind information from job.
 	accessor, err := meta.TypeAccessor(job)
 	if err != nil {
 		return nil, err
 	}
-	apiVersion := accessor.GetAPIVersion()
-	kind := accessor.GetKind()
 
-	// Inject binding relationship into pod group by append owner reference.
-	gang_schedule.AppendOwnerReference(podGroup, metav1.OwnerReference{
-		APIVersion:         apiVersion,
-		Kind:               kind,
-		Name:               job.GetName(),
-		UID:                job.GetUID(),
-		BlockOwnerDeletion: pointer.BoolPtr(true),
-		Controller:         pointer.BoolPtr(true),
-	})
+	var (
+		apiVersion = accessor.GetAPIVersion()
+		kind       = accessor.GetKind()
+		podGroups  *v1beta1.PodGroupList
+	)
 
-	err = vs.client.Create(context.Background(), podGroup)
-	return podGroup, err
+	// If DAG scheduling is enabled, kubedl will create individual podgrpoups entity for each role
+	// to represent a separate stage, otherwise podgrpoups entity will be created in job granularity.
+	if features.KubeDLFeatureGates.Enabled(features.DAGScheduling) {
+		podGroups = vs.generateGangByRoleUnit(apiVersion, kind, job.GetName(), job.GetNamespace(), job.GetUID(), replicas)
+	} else {
+		podGroups = vs.generateGangByJobUnit(apiVersion, kind, job.GetName(), job.GetNamespace(), job.GetUID(), replicas, schedPolicy)
+	}
+
+	for i := range podGroups.Items {
+		pg := &podGroups.Items[i]
+		err = vs.client.Get(context.Background(), types.NamespacedName{Name: pg.Name, Namespace: pg.Namespace}, &v1beta1.PodGroup{})
+		if err != nil && errors.IsNotFound(err) {
+			err = vs.client.Create(context.Background(), pg)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return podGroups, err
 }
 
-func (vs *volcanoScheduler) BindPodToGang(obj metav1.Object, entity runtime.Object) error {
-	podSpec := obj.(*v1.PodTemplateSpec)
-	podGroup := entity.(*v1beta1.PodGroup)
-	// The newly-created pods should be submitted to target gang scheduler.
-	if podSpec.Spec.SchedulerName == "" || podSpec.Spec.SchedulerName != vs.Name() {
-		podSpec.Spec.SchedulerName = vs.Name()
+func (vs *volcanoScheduler) BindPodToGang(job metav1.Object, podSpec *v1.PodTemplateSpec, gangEntity runtime.Object, rtype string) error {
+	podGroups, ok := gangEntity.(*v1beta1.PodGroupList)
+	if !ok {
+		klog.Warningf("podgrpoups entity cannot convert to podgrpoups list, entity: %+v", gangEntity)
+		return nil
 	}
+	if len(podGroups.Items) == 0 {
+		return fmt.Errorf("unexpected empty podgrpoups entity list, job name: %s", job.GetName())
+	}
+
+	podGroupName := job.GetName()
+	matchLabels := map[string]string{apiv1.LabelGangSchedulingJobName: job.GetName()}
+	if features.KubeDLFeatureGates.Enabled(features.DAGScheduling) {
+		matchLabels[apiv1.ReplicaTypeLabel] = rtype
+		podGroupName = fmt.Sprintf("%s-%s", job.GetName(), rtype)
+	}
+	selector := labels.SelectorFromSet(matchLabels)
+
+	for i := range podGroups.Items {
+		pg := &podGroups.Items[i]
+		if pg.Labels != nil && selector.Matches(labels.Set(pg.Labels)) {
+			gang_schedule.AppendOwnerReference(podSpec, metav1.OwnerReference{
+				APIVersion:         pg.APIVersion,
+				Kind:               pg.Kind,
+				Name:               pg.Name,
+				UID:                pg.UID,
+				Controller:         pointer.BoolPtr(false),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			})
+			podGroupName = pg.Name
+			break
+		}
+	}
+
 	if podSpec.Annotations == nil {
 		podSpec.Annotations = map[string]string{}
 	}
-	podSpec.Annotations[v1beta1.KubeGroupNameAnnotationKey] = podGroup.GetName()
+	podSpec.Annotations[v1beta1.KubeGroupNameAnnotationKey] = podGroupName
 	return nil
 }
 
 func (vs *volcanoScheduler) GetGang(name types.NamespacedName) (runtime.Object, error) {
-	podGroup := &v1beta1.PodGroup{}
-	if err := vs.client.Get(context.Background(), name, podGroup); err != nil {
+	podGroups := &v1beta1.PodGroupList{}
+	if err := vs.client.List(context.Background(), podGroups, client.MatchingLabels{
+		apiv1.LabelGangSchedulingJobName: name.Name,
+	}, client.InNamespace(name.Namespace)); err != nil {
 		return nil, err
 	}
-	return podGroup, nil
+	return podGroups, nil
 }
 
 func (vs *volcanoScheduler) DeleteGang(name types.NamespacedName) error {
-	podGroup, err := vs.GetGang(name)
+	pgs, err := vs.GetGang(name)
 	if err != nil {
 		return err
 	}
-	err = vs.client.Delete(context.Background(), podGroup)
-	// Discard deleted pod group object.
-	if err != nil && errors.IsNotFound(err) {
-		return nil
+	podGroups := pgs.(*v1beta1.PodGroupList)
+
+	for i := range podGroups.Items {
+		pg := &podGroups.Items[i]
+		if err = vs.client.Delete(context.Background(), pg); err != nil {
+			return err
+		}
 	}
 	return err
+}
+
+func (vs *volcanoScheduler) generateGangByJobUnit(apiVersion, kind, name, namespace string, uid types.UID, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec, schedPolicy *apiv1.SchedulingPolicy) *v1beta1.PodGroupList {
+	pg := v1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{apiv1.LabelGangSchedulingJobName: name},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         apiVersion,
+					Kind:               kind,
+					Name:               name,
+					UID:                uid,
+					Controller:         pointer.BoolPtr(true),
+					BlockOwnerDeletion: pointer.BoolPtr(true),
+				},
+			},
+		},
+		Spec: v1beta1.PodGroupSpec{MinMember: k8sutil.GetTotalReplicas(replicas)},
+	}
+
+	if schedPolicy != nil && schedPolicy.MinAvailable != nil && *schedPolicy.MinAvailable > 0 {
+		pg.Spec.MinMember = *schedPolicy.MinAvailable
+	}
+
+	return &v1beta1.PodGroupList{Items: []v1beta1.PodGroup{pg}}
+}
+
+func (vs *volcanoScheduler) generateGangByRoleUnit(apiVersion, kind, name, namespace string, uid types.UID, replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) *v1beta1.PodGroupList {
+	pgs := v1beta1.PodGroupList{Items: make([]v1beta1.PodGroup, 0, len(replicas))}
+
+	for rtype, spec := range replicas {
+		rt := strings.ToLower(string(rtype))
+		gangName := fmt.Sprintf("%s-%s", name, rt)
+		pgs.Items = append(pgs.Items, v1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gangName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					apiv1.LabelGangSchedulingJobName: name,
+					apiv1.ReplicaTypeLabel:           rt,
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         apiVersion,
+						Kind:               kind,
+						Name:               name,
+						UID:                uid,
+						Controller:         pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.BoolPtr(true),
+					},
+				},
+			},
+			Spec: v1beta1.PodGroupSpec{MinMember: *spec.Replicas},
+		})
+	}
+
+	return &pgs
 }

--- a/pkg/gang_schedule/volcano_scheduler/scheduler_test.go
+++ b/pkg/gang_schedule/volcano_scheduler/scheduler_test.go
@@ -1,56 +1,448 @@
 package volcano_scheduler
 
 import (
-	testutilv1 "github.com/alibaba/kubedl/pkg/test_util/v1"
-	"github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
-	testjobv1 "github.com/alibaba/kubedl/pkg/test_job/v1"
+	"github.com/alibaba/kubedl/apis"
+	trainingv1alpha1 "github.com/alibaba/kubedl/apis/training/v1alpha1"
+	"github.com/alibaba/kubedl/pkg/features"
+	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
 )
 
-func TestCreateGang(t *testing.T) {
-	testCases := []int{
-		1, 2, 3, 9,
+func TestVolcano_CreateGang(t *testing.T) {
+	tfGVK := schema.GroupVersionKind{
+		Group:   trainingv1alpha1.GroupVersion.Group,
+		Version: trainingv1alpha1.GroupVersion.Version,
+		Kind:    trainingv1alpha1.TFJobKind,
+	}
+	pytorchGVK := schema.GroupVersionKind{
+		Group:   trainingv1alpha1.GroupVersion.Group,
+		Version: trainingv1alpha1.GroupVersion.Version,
+		Kind:    trainingv1alpha1.PyTorchJobKind,
+	}
+	testCases := []struct {
+		name       string
+		job        metav1.Object
+		podgrpoups v1beta1.PodGroupList
+		dag        bool
+	}{
+		{
+			name:       "input tf job with 1 ps and 1 worker and no run policy",
+			job:        createTFJob("job-1", 1, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-1", "", "job-1", "", 2, metav1.NewControllerRef(createTFJob("job-1", 1, nil), tfGVK))}},
+		},
+		{
+			name:       "input tf job with 1 ps and 3 worker and no run policy",
+			job:        createTFJob("job-2", 3, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-2", "", "job-2", "", 4, metav1.NewControllerRef(createTFJob("job-2", 3, nil), tfGVK))}},
+		},
+		{
+			name: "input tf job with 1 ps and 3 worker and min-available(2) in run policy",
+			job: createTFJob("job-3", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+				MinAvailable: pointer.Int32Ptr(2)}}),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-3", "", "job-3", "", 2,
+				metav1.NewControllerRef(createTFJob("job-3", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+					MinAvailable: pointer.Int32Ptr(2)}}), tfGVK))}},
+		},
+		{
+			name: "input pytorch job with 1 worker and no run policy",
+			job:  createPytorchJob("job-4", 1, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-4", "", "job-4", "", 1, metav1.NewControllerRef(
+				createTFJob("job-4", 1, nil), pytorchGVK))}},
+		},
+		{
+			name: "input pytorch job with 3 worker and no run policy",
+			job:  createPytorchJob("job-5", 3, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-5", "", "job-5", "", 3, metav1.NewControllerRef(
+				createPytorchJob("job-5", 3, nil), pytorchGVK))}},
+		},
+		{
+			name: "input pytorch job with 3 worker and min-available(2) in run policy",
+			job: createPytorchJob("job-6", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+				MinAvailable: pointer.Int32Ptr(2)}}),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-6", "", "job-6", "", 2, metav1.NewControllerRef(
+				createTFJob("job-6", 3, &v1.RunPolicy{SchedulingPolicy: &v1.SchedulingPolicy{
+					MinAvailable: pointer.Int32Ptr(2)}}), pytorchGVK))}},
+		},
+		{
+			name: "input tf job with ps+worker and dag enabled.",
+			job:  createTFJob("job-7", 1, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{
+				createPodGroup("job-7-ps", "", "job-7", "ps", 1, metav1.NewControllerRef(createTFJob("job-7", 1, nil), tfGVK)),
+				createPodGroup("job-7-worker", "", "job-7", "worker", 1, metav1.NewControllerRef(createTFJob("job-7", 1, nil), tfGVK)),
+			}},
+			dag: true,
+		},
+		{
+			name: "input pytorch job with worker only and dag enabled.",
+			job:  createPytorchJob("job-8", 3, nil),
+			podgrpoups: v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-8-worker", "", "job-8", "worker", 3, metav1.NewControllerRef(
+				createPytorchJob("job-8", 3, nil), pytorchGVK))}},
+			dag: true,
+		},
 	}
 
-	for _, workerNumber := range testCases {
-		scheme := runtime.NewScheme()
-		_ = corev1.AddToScheme(scheme)
-		_ = testjobv1.AddToScheme(scheme)
-		testJob := testutilv1.NewTestJob(workerNumber)
-		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
-		testScheduler := &volcanoScheduler{client: fakeClient}
+	dagEnabled := features.KubeDLFeatureGates.Enabled(features.DAGScheduling)
+	defer features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): dagEnabled})
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
-		testPodGroup := testObject.(*v1beta1.PodGroup)
-		assert.Equal(t, testPodGroup.Name, testutilv1.TestJobName)
-		assert.Equal(t, testPodGroup.Namespace, metav1.NamespaceDefault)
-		assert.Equal(t, testPodGroup.Spec.MinMember, int32(workerNumber))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = apis.AddToScheme(scheme)
+			_ = v1beta1.AddToScheme(scheme)
+			us := volcanoScheduler{client: fake.NewFakeClientWithScheme(scheme)}
+
+			var (
+				specs     map[v1.ReplicaType]*v1.ReplicaSpec
+				runPolicy *v1.RunPolicy
+			)
+
+			switch testCase.job.(type) {
+			case *trainingv1alpha1.TFJob:
+				specs = testCase.job.(*trainingv1alpha1.TFJob).Spec.TFReplicaSpecs
+				runPolicy = &testCase.job.(*trainingv1alpha1.TFJob).Spec.RunPolicy
+			case *trainingv1alpha1.PyTorchJob:
+				specs = testCase.job.(*trainingv1alpha1.PyTorchJob).Spec.PyTorchReplicaSpecs
+				runPolicy = &testCase.job.(*trainingv1alpha1.PyTorchJob).Spec.RunPolicy
+			default:
+				t.Errorf("unknown test job type: %v", testCase.job)
+				return
+			}
+
+			// only for test
+			features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): testCase.dag})
+
+			gang, err := us.CreateGang(testCase.job, specs, runPolicy.SchedulingPolicy)
+			if err != nil {
+				t.Errorf("failed to create podgrpoups, err: %v", err)
+			}
+
+			gang, err = us.GetGang(types.NamespacedName{Namespace: testCase.job.GetNamespace(), Name: testCase.job.GetName()})
+			if err != nil {
+				t.Errorf("failed to get latest podgrpoups, err: %v", err)
+			}
+			testCase.podgrpoups.TypeMeta = metav1.TypeMeta{Kind: "PodGroupList", APIVersion: "scheduling.volcano.sh/v1beta1"}
+
+			sort.SliceStable(gang.(*v1beta1.PodGroupList).Items, func(i, j int) bool {
+				return gang.(*v1beta1.PodGroupList).Items[i].Name < gang.(*v1beta1.PodGroupList).Items[j].Name
+			})
+			sort.SliceStable(testCase.podgrpoups.Items, func(i, j int) bool {
+				return testCase.podgrpoups.Items[i].Name < testCase.podgrpoups.Items[j].Name
+			})
+
+			if !equality.Semantic.DeepEqual(gang, &testCase.podgrpoups) {
+				t.Errorf("unexpected podgrpoups result, expected: %+v, got: %+v", &testCase.podgrpoups, gang)
+			}
+		})
 	}
 }
 
-func TestBindPodToGang(t *testing.T) {
-	testCases := []int{
-		1, 2, 3, 9,
+func TestVolcano_BindPodToGang(t *testing.T) {
+	testCases := []struct {
+		name         string
+		job          metav1.Object
+		gang         v1beta1.PodGroupList
+		podSpec      *corev1.PodTemplateSpec
+		rtype        string
+		expectedSpec *corev1.PodTemplateSpec
+		dag          bool
+	}{
+		{
+			name:    "bind pod for tf job ps",
+			job:     createTFJob("job-1", 1, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-1", "12345", "job-1", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "ps",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-1"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-1",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job worker(total 1, index 0)",
+			job:     createTFJob("job-2", 1, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-2", "12345", "job-2", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-2"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-2",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job worker(total 3, index 1)",
+			job:     createTFJob("job-3", 3, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-3", "12345", "job-3", "", 3, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-3"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-3",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for pytorch job worker(total 1, index 0)",
+			job:     createPytorchJob("job-4", 1, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-4", "12345", "job-4", "", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-4"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-4",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for pytorch job worker(total 3, index 1)",
+			job:     createPytorchJob("job-5", 3, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-5", "12345", "job-5", "", 3, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-5"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-5",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+		},
+		{
+			name:    "bind pod for tf job ps and dag enabled",
+			job:     createTFJob("job-6", 1, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-6-ps", "12345", "job-6", "ps", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "ps",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-6-ps"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-6-ps",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+			dag: true,
+		},
+		{
+			name:    "bind pod for tf job worker and dag enabled",
+			job:     createTFJob("job-7", 1, nil),
+			gang:    v1beta1.PodGroupList{Items: []v1beta1.PodGroup{createPodGroup("job-7-worker", "12345", "job-7", "worker", 1, nil)}},
+			podSpec: &corev1.PodTemplateSpec{},
+			rtype:   "worker",
+			expectedSpec: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: "job-7-worker"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "scheduling.volcano.sh/v1beta1",
+							Kind:               "PodGroup",
+							Name:               "job-7-worker",
+							UID:                "12345",
+							Controller:         pointer.BoolPtr(false),
+							BlockOwnerDeletion: pointer.BoolPtr(true),
+						},
+					}},
+			},
+			dag: true,
+		},
 	}
 
-	for _, workerNumber := range testCases {
-		scheme := runtime.NewScheme()
-		_ = corev1.AddToScheme(scheme)
-		_ = testjobv1.AddToScheme(scheme)
-		testJob := testutilv1.NewTestJob(workerNumber)
-		fakeClient := fake.NewFakeClientWithScheme(scheme, testJob)
-		testScheduler := &volcanoScheduler{client: fakeClient}
+	dagEnabled := features.KubeDLFeatureGates.Enabled(features.DAGScheduling)
+	defer features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): dagEnabled})
 
-		testObject, _ := testScheduler.CreateGang(testJob, testJob.Spec.TestReplicaSpecs)
-		testPodGroup := testObject.(*v1beta1.PodGroup)
-		testPodSpec := testutilv1.NewTestReplicaSpecTemplate()
-		testScheduler.BindPodToGang(&testPodSpec, testPodGroup)
-		assert.Equal(t, testPodSpec.Annotations[v1beta1.KubeGroupNameAnnotationKey], testPodGroup.Name)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = apis.AddToScheme(scheme)
+			_ = v1beta1.AddToScheme(scheme)
+			us := volcanoScheduler{client: fake.NewFakeClientWithScheme(scheme)}
+			// only for test
+			features.KubeDLFeatureGates.SetFromMap(map[string]bool{string(features.DAGScheduling): testCase.dag})
+			for i := range testCase.gang.Items {
+				testCase.gang.Items[i].TypeMeta = metav1.TypeMeta{APIVersion: "scheduling.volcano.sh/v1beta1", Kind: "PodGroup"}
+			}
+			err := us.BindPodToGang(testCase.job, testCase.podSpec, &testCase.gang, testCase.rtype)
+			if err != nil {
+				t.Errorf("failed to bind pod to podgrpoups, err: %v", err)
+			}
+			if !equality.Semantic.DeepEqual(testCase.expectedSpec, testCase.podSpec) {
+				t.Errorf("unexpected bind result, expected: %+v, got: %+v", testCase.expectedSpec, testCase.podSpec)
+			}
+		})
 	}
+}
+
+func createTFJob(jobName string, workerReplicas int32, runPolicy *v1.RunPolicy) *trainingv1alpha1.TFJob {
+	job := &trainingv1alpha1.TFJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: trainingv1alpha1.GroupVersion.String(),
+			Kind:       trainingv1alpha1.TFJobKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "default",
+			UID:       "12345",
+		},
+
+		Spec: trainingv1alpha1.TFJobSpec{
+			TFReplicaSpecs: map[v1.ReplicaType]*v1.ReplicaSpec{
+				"PS": {
+					Replicas:      pointer.Int32Ptr(1),
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+				"Worker": {
+					Replicas:      &workerReplicas,
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if runPolicy != nil {
+		job.Spec.RunPolicy = *runPolicy
+	}
+	return job
+}
+
+func createPytorchJob(jobName string, workerReplicas int32, runPolicy *v1.RunPolicy) *trainingv1alpha1.PyTorchJob {
+	job := &trainingv1alpha1.PyTorchJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: trainingv1alpha1.GroupVersion.String(),
+			Kind:       trainingv1alpha1.PyTorchJobKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "default",
+			UID:       "12345",
+		},
+
+		Spec: trainingv1alpha1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[v1.ReplicaType]*v1.ReplicaSpec{
+				"Worker": {
+					Replicas:      &workerReplicas,
+					RestartPolicy: "Never",
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "tensorflow",
+									Image: "kubedl/tf-mnist-with-summaries:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if runPolicy != nil {
+		job.Spec.RunPolicy = *runPolicy
+	}
+	return job
+}
+
+func createPodGroup(name, uid, jobName, rtype string, minMember int32, owner *metav1.OwnerReference) v1beta1.PodGroup {
+	pg := v1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "default",
+			ResourceVersion: "1",
+			Labels:          map[string]string{},
+		},
+		Spec: v1beta1.PodGroupSpec{MinMember: minMember},
+	}
+	if uid != "" {
+		pg.UID = types.UID(uid)
+	}
+	if owner != nil {
+		pg.OwnerReferences = append(pg.OwnerReferences, *owner)
+	}
+	if jobName != "" {
+		pg.Labels[v1.LabelGangSchedulingJobName] = jobName
+	}
+	if rtype != "" {
+		pg.Labels[v1.ReplicaTypeLabel] = rtype
+	}
+	return pg
 }

--- a/pkg/job_controller/api/v1/constants.go
+++ b/pkg/job_controller/api/v1/constants.go
@@ -50,6 +50,8 @@ const (
 	LabelModelVersion = KubeDLPrefix + "/model-version"
 	// LabelCronName indicates the name of cron who created this job.
 	LabelCronName = KubeDLPrefix + "/cron-name"
+	// LabelGangSchedulingJobName indicates name of gang scheduled job.
+	LabelGangSchedulingJobName = KubeDLPrefix + "/gang-job-name"
 )
 
 // NetworkMode defines network mode for intra job communicating.

--- a/pkg/job_controller/job.go
+++ b/pkg/job_controller/job.go
@@ -233,7 +233,7 @@ func (jc *JobController) ReconcileJobs(job interface{}, replicas map[apiv1.Repli
 
 	if jc.Config.EnableGangScheduling {
 		log.Infof("gang schedule enabled, start to syncing for job %s", jobKey)
-		if _, err = jc.CreateGang(metaObject, replicas); err != nil {
+		if _, err = jc.CreateGang(metaObject, replicas, runPolicy.SchedulingPolicy); err != nil {
 			return result, err
 		}
 	}

--- a/pkg/test_util/v1/test_job_util.go
+++ b/pkg/test_util/v1/test_job_util.go
@@ -36,6 +36,7 @@ func NewTestJob(worker int) *testjobv1.TestJob {
 		},
 		Spec: testjobv1.TestJobSpec{
 			TestReplicaSpecs: make(map[apiv1.ReplicaType]*apiv1.ReplicaSpec),
+			RunPolicy:        &apiv1.RunPolicy{},
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. split gang entities by job role when DAG is enabled to eliminate dead lock.
2. optimize gang interface to explicitly distinguish plugin name with scheduler name.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #229 

### III. Special notes for reviewers if any.


