### PR TITLE
fix missing permission required

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,14 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Signed-off-by: Aero Kang <rphoho@gmail.com>

I. Describe what this PR does
修复dashboard权限不足导致页面卡死
```
E0209 13:37:36.767187       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.7/tools/cache/reflector.go:167: Failed to watch *v1.Node: unknown (get nodes)
E0209 13:37:52.696184       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.7/tools/cache/reflector.go:167: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kubedl-system:default" cannot list resource "namespaces" in API group "" at the cluster scope

E0209 13:42:19.072571       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.7/tools/cache/reflector.go:167: Failed to watch *v1.Namespace: unknown (get namespaces)
E0209 13:42:33.435321       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.7/tools/cache/reflector.go:167: Failed to watch *v1.Node: unknown (get nodes)
```

II. Does this pull request fix one issue?
No

III. Special notes for reviewers if any.
No