### PR TITLE
feat: adapt volcano queue api in scheduling policy.

### DIFF
--- a/pkg/gang_schedule/volcano_scheduler/scheduler_test.go
+++ b/pkg/gang_schedule/volcano_scheduler/scheduler_test.go
@@ -423,6 +423,7 @@ func createPytorchJob(jobName string, workerReplicas int32, runPolicy *v1.RunPol
 }
 
 func createPodGroup(name, uid, jobName, rtype string, minMember int32, owner *metav1.OwnerReference) v1beta1.PodGroup {
+	empty := make(corev1.ResourceList)
 	pg := v1beta1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -430,7 +431,7 @@ func createPodGroup(name, uid, jobName, rtype string, minMember int32, owner *me
 			ResourceVersion: "1",
 			Labels:          map[string]string{},
 		},
-		Spec: v1beta1.PodGroupSpec{MinMember: minMember},
+		Spec: v1beta1.PodGroupSpec{MinMember: minMember, MinResources: &empty},
 	}
 	if uid != "" {
 		pg.UID = types.UID(uid)

--- a/pkg/util/resource_utils/resources.go
+++ b/pkg/util/resource_utils/resources.go
@@ -37,6 +37,24 @@ func MaximumContainersResources(containers []v1.Container) v1.ResourceRequiremen
 	return max
 }
 
+func JobResourceRequests(replicas map[apiv1.ReplicaType]*apiv1.ReplicaSpec) v1.ResourceList {
+	result := make(v1.ResourceList)
+	for _, rspec := range replicas {
+		result = quota.Add(result, ReplicaResourceRequests(rspec))
+	}
+
+	return result
+}
+
+func ReplicaResourceRequests(rspec *apiv1.ReplicaSpec) v1.ResourceList {
+	resources := ComputePodSpecResourceRequest(&rspec.Template.Spec)
+	replicas := int32(1)
+	if rspec.Replicas != nil {
+		replicas = *rspec.Replicas
+	}
+	return Multiply(int64(replicas), resources)
+}
+
 // ComputePodResourceRequest returns the requested resource of the Pod
 func ComputePodResourceRequest(pod *v1.Pod) v1.ResourceList {
 	return ComputePodSpecResourceRequest(&pod.Spec)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

1. deliver Queue name through schedulingPolicy to volcano podgroup api
2. calculate minResources in role or job unit corresponding to DAGScheduling enabled or not.

### II. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### III. Special notes for reviewers if any.


