### PR TITLE
including go install in Makefile as functionality to do so via go get…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ release: helm-chart
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
As doing go install via go get has been deprecated, using Makefile without including go install creates a hassle for developers and they need to look out for the issue that is persisting while debugging. This can be fixed by simply including go install in the Makefile.